### PR TITLE
PyYAML treats numbers with leading 0 as strings - Go doesn't

### DIFF
--- a/lib/kube_yaml.py
+++ b/lib/kube_yaml.py
@@ -15,6 +15,11 @@ try:
 except ImportError:
     from StringIO import StringIO
 
+try:
+    _ = basestring
+except NameError:
+    basestring = str
+
 __all__ = ['quoted', 'literal', 'yaml_safe_dump', 'yaml_load']
 
 # This file is very magical, allowing for a few deep dives in the inner workings of the pyyaml
@@ -37,10 +42,13 @@ class FakeStringIO(object):
 
 class BlockRepresenter(yaml.representer.BaseRepresenter):
     def represent_scalar(self, tag, value, style=None):
-        if style is None and not isinstance(value, VarEntity):
+        if tag.endswith(':str') and isinstance(value, basestring) and value != '' and value.strip('0123456789') == '':
+            style = "'"
+        elif style is None and not isinstance(value, VarEntity):
             for c in u"\u000a\u000d\u001c\u001d\u001e\u0085\u2028\u2029":
                 if c in value:
                     style = '|'
+
         return yaml.representer.BaseRepresenter.represent_scalar(self, tag, value, style=style)
 
 

--- a/test/test/test_yaml.py
+++ b/test/test/test_yaml.py
@@ -44,5 +44,18 @@ qux: |-
 """
         self.assertEqual(kube_yaml.yaml_safe_dump(src).strip(), dst.strip())
 
+    def test_quote_all_numbers(self):
+        # the go yaml parser appears to interpret numbers with leading zeros as numbers
+        # while py_yaml interprets them as strings. We now force this to be quoted in
+        # rubiks.
+        src = {'foo': '0012345'}
+        dst = "foo: '0012345'"
+        self.assertEqual(kube_yaml.yaml_safe_dump(src).strip(), dst.strip())
+        src = {'foo': '12345'}
+        dst = "foo: '12345'"
+        self.assertEqual(kube_yaml.yaml_safe_dump(src).strip(), dst.strip())
+        src = {'foo': '0012345abc'}
+        dst = "foo: 0012345abc"
+        self.assertEqual(kube_yaml.yaml_safe_dump(src).strip(), dst.strip())
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Strictly, !!int needs canonicalisation in YAML so a bare "number" starting
with 0s should parse as !!str, but Go (in some versions?) treats it as
!!int instead. Since Rubiks is clearly designed to work with kubectl and
oc, we need to make sure that we do the best thing for the Go parser here.
Add a test for this case.