### PR TITLE
WIP: Added docgen command

### DIFF
--- a/lib/commands/docgen.py
+++ b/lib/commands/docgen.py
@@ -1,0 +1,65 @@
+# (c) Copyright 2017-2018 OLX
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+from command import Command
+from .bases import CommandRepositoryBase
+import load_python
+import os
+
+class Command_docgen(Command, CommandRepositoryBase):
+    """
+    Generate the documentation of all classes supported by rubiks on your local rubiks folder.
+    """
+
+    _documentation = """
+    This document is automatically generated using the command `docgen` and describe all the object and types that can be used inside Rubiks to configure your cluster
+    
+    It is possible to generate this documentation locally running inside your rubiks repo `rubiks docgen`.
+    """
+
+    def populate_args(self, parser):
+        pass
+
+    def run(self, args):
+        self.get_repository(can_fail=True)
+        objs = load_python.PythonBaseFile.get_kube_objs()
+        types = load_python.PythonBaseFile.get_kube_types()
+        formats = load_python.PythonBaseFile.get_kube_vartypes()
+        
+        r = self.get_repository()
+
+        doc = '\n'.join([line.strip() for line in self._documentation.split('\n')])
+
+        md = ''
+        header = '<p align="center"><img src="logos/rubiks-logo-horizontal.png" title="Rubiks Logo"></p>\n\n'
+        header += '# Rubiks Object Index\n{}\n\n'.format(doc)
+        header += '# Table of contents\n\n'
+
+        header += '- [Formats](#formats)\n'
+        md += '\n# Formats\n\n'
+        for fname in sorted(formats.keys()):
+            header += '  - [{}](#{})\n'.format(fname, fname.lower())
+            md += '## {}\n\n'.format(fname)
+            md += '{}\n\n'.format(formats[fname].get_description())
+
+        header += '- [Types](#types)\n'
+        md += '\n# Types\n\n'
+        for tname in sorted(types.keys()):
+            header += '  - [{}](#{})\n'.format(tname, tname.lower())
+            md += '## {}\n\n'.format(tname)
+            md += '{}\n\n'.format(types[tname].get_description())
+
+
+        header += '- [Objects](#objects)\n'
+        md += '\n# Objects\n\n'
+        for oname in sorted(objs.keys()):
+            header += '  - [{}](#{})\n'.format(oname, oname.lower())
+            md += objs[oname].get_help().render_markdown()
+
+        with open(os.path.join(r.basepath, 'docs/rubiks.class.md'), 'w') as f:
+            f.write(header.encode('utf-8'))
+            f.write(md.encode('utf-8'))

--- a/lib/kube_types.py
+++ b/lib/kube_types.py
@@ -61,6 +61,12 @@ class KubeType(object):
             ret = Object(ret.__class__)
 
         return ret
+    
+    @classmethod
+    def get_description(cls):
+        if cls.__doc__ is not None and cls.__doc__ is not '':
+            return '\n'.join([line.strip() for line in cls.__doc__.split('\n')])
+        return 'TODO: Description is still missing from the class docstring.\nStay tuned to have more hint about this variable.'
 
     def original_type(self):
         if self.wrapper:

--- a/lib/var_types.py
+++ b/lib/var_types.py
@@ -133,3 +133,10 @@ class VarEntity(object):
         if self.renderer is None:
             return self._internal_render()
         return self.renderer(self._internal_render())
+    
+    @classmethod
+    def get_description(cls):
+        if cls.__doc__ is not None and cls.__doc__ is not '':
+            return '\n'.join([line.strip() for line in cls.__doc__.split('\n')])
+        return 'TODO: Description is still missing from the class docstring.\nStay tuned to have more hint about this variable.'
+


### PR DESCRIPTION
This new command can be used to generate markdown documentation for any rubiks setup.
If run with modules all the objects included into the modules will be automatically added inside the generated markdown.

the markdown will be placed inside `docs/rubiks.class.md`

**TODO:**
- Define if the file position is ok.
- Define if all the section naming is appropriate.
- Define if we like to ship in this merge request all the class docstrings or if it will be better to send them on another PR.

**Sections**
- Formats
  - Base64
  - Command
  - Confidential
  - JSON
  - YAML
- Types
  - ARN
  - Boolean
  - CaseIdentifier
  - ColonIdentifier
  - Domain
  - Enum
  - IP
  - IPv4
  - Identifier
  - Integer
  - List
  - NonEmpty
  - NonZero
  - Nullable
  - Number
  - Path
  - Positive
  - String
  - SurgeSpec
  - SystemIdentifier
  - WildcardDomain
- Objects
  - Too many to be there :)